### PR TITLE
Adding auth settings

### DIFF
--- a/mlserver/kafka/server.py
+++ b/mlserver/kafka/server.py
@@ -27,13 +27,30 @@ class KafkaServer:
         self._handlers = KafkaHandlers(data_plane)
 
     def _create_server(self):
-        self._consumer = AIOKafkaConsumer(
-            self._settings.kafka_topic_input,
-            bootstrap_servers=self._settings.kafka_servers,
-        )
-        self._producer = AIOKafkaProducer(
-            bootstrap_servers=self._settings.kafka_servers
-        )
+        if self._settings.kafka_auth_enabled:
+            self._consumer = AIOKafkaConsumer(
+                self._settings.kafka_topic_input,
+                bootstrap_servers=self._settings.kafka_servers,
+                security_protocol=self._settings.kafka_security_protocol,
+                sasl_mechanism=self._settings.kafka_sasl_mechanism,
+                sasl_plain_username=self._settings.kafka_sasl_plain_username,
+                sasl_plain_password=self._settings.kafka_sasl_plain_password
+            )
+            self._producer = AIOKafkaProducer(
+                bootstrap_servers=self._settings.kafka_servers,
+                security_protocol=self._settings.kafka_security_protocol,
+                sasl_mechanism=self._settings.kafka_sasl_mechanism,
+                sasl_plain_username=self._settings.kafka_sasl_plain_username,
+                sasl_plain_password=self._settings.kafka_sasl_plain_password
+            )
+        else:
+            self._consumer = AIOKafkaConsumer(
+                self._settings.kafka_topic_input,
+                bootstrap_servers=self._settings.kafka_servers,
+            )
+            self._producer = AIOKafkaProducer(
+                bootstrap_servers=self._settings.kafka_servers
+            )
 
     async def add_custom_handlers(self, model: MLModel):
         # TODO: Implement

--- a/mlserver/kafka/server.py
+++ b/mlserver/kafka/server.py
@@ -54,7 +54,7 @@ class KafkaServer:
                 sasl_mechanism=self._settings.kafka_sasl_mechanism,
                 sasl_plain_username=self._settings.kafka_sasl_plain_username,
                 sasl_plain_password=self._settings.kafka_sasl_plain_password,
-                ssl_context=create_ssl_context
+                ssl_context=ssl_context
             )
         else:
             self._consumer = AIOKafkaConsumer(

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -231,6 +231,14 @@ class Settings(BaseSettings):
     kafka_servers: str = "localhost:9092"
     kafka_topic_input: str = "mlserver-input"
     kafka_topic_output: str = "mlserver-output"
+    kafka_auth_enabled: bool = False
+    """If Kafka auth is enabled use the authentication options for `security_protocol` and `sasl_mechanism` in 
+    aiokafka documentation (https://aiokafka.readthedocs.io/en/stable/api.html#api-documentation)"""
+    kafka_security_protocol: str = "PLAINTEXT"
+    kafka_sasl_mechanism: str = "PLAIN"
+    kafka_sasl_plain_username: str
+    kafka_sasl_plain_password: str
+
 
     # OpenTelemetry Tracing settings
     tracing_server: Optional[str] = None

--- a/mlserver/settings.py
+++ b/mlserver/settings.py
@@ -236,8 +236,12 @@ class Settings(BaseSettings):
     aiokafka documentation (https://aiokafka.readthedocs.io/en/stable/api.html#api-documentation)"""
     kafka_security_protocol: str = "PLAINTEXT"
     kafka_sasl_mechanism: str = "PLAIN"
-    kafka_sasl_plain_username: str
-    kafka_sasl_plain_password: str
+    kafka_sasl_plain_username: Optional[str] = None
+    kafka_sasl_plain_password: Optional[str] = None
+    kafka_ssl_ca_file: Optional[str] = None
+    kafka_ssl_cert_file: Optional[str] = None
+    kafka_ssl_key_file: Optional[str] = None
+    kafka_ssl_key_password: Optional[str] = None
 
 
     # OpenTelemetry Tracing settings


### PR DESCRIPTION
Not sure if we want to merge this to our main branch or not. However, I did a very basic test and the MLServer kafka server starts with default values - you might have to test various values in `settings.json` but should pass all values to right code akin to this example: https://gist.github.com/alexlopes/72fea4e4da623ef8f60a800d6a962f2f but using `aiokafka` 
And matched SSL usage to lib code and example here https://aiokafka.readthedocs.io/en/stable/examples/ssl_consume_produce.html#ssl-example